### PR TITLE
Fix "undefined reference to <math function>" error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 OBJS=kmeans.o
 EXE=example1 example2
 
-CFLAGS=-g -O0
+CFLAGS=-g -O0 -lm
 
 all: $(EXE)
 


### PR DESCRIPTION
On my machine, without adding `-lm`:
```
root@37c3d19aeab8:/src/kmeans# make example2
cc -g -O0   -c -o kmeans.o kmeans.c
cc -g -O0   -c -o example2.o example2.c
cc -g -O0 kmeans.o example2.o -o example2
example2.o: In function `main':
/src/kmeans/example2.c:97: undefined reference to `log2'
/src/kmeans/example2.c:97: undefined reference to `sqrt'
/src/kmeans/example2.c:97: undefined reference to `cos'
/src/kmeans/example2.c:98: undefined reference to `log2'
/src/kmeans/example2.c:98: undefined reference to `sqrt'
/src/kmeans/example2.c:98: undefined reference to `sin'
/src/kmeans/example2.c:113: undefined reference to `lround'
collect2: error: ld returned 1 exit status
Makefile:15: recipe for target 'example2' failed
make: *** [example2] Error 1
```

And after adding `-lm`, success:

```
root@37c3d19aeab8:/src/kmeans# make clean
root@37c3d19aeab8:/src/kmeans# make example2
cc -g -O0 -lm   -c -o kmeans.o kmeans.c
cc -g -O0 -lm   -c -o example2.o example2.c
cc -g -O0 -lm kmeans.o example2.o -o example2
```